### PR TITLE
Centralize crawler signatures

### DIFF
--- a/signatures/index.ts
+++ b/signatures/index.ts
@@ -1,0 +1,6 @@
+import llmSignaturesMap from './llm'
+
+const LLM_SIGNATURES = Object.values(llmSignaturesMap)
+
+export default LLM_SIGNATURES
+

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,16 +1,5 @@
 import { NextResponse } from "next/server";
-
-const LLM_SIGNATURES: { family: string; regex: RegExp }[] = [
-  { family: "Claude", regex: /Claude(?:Bot)?/i },
-  { family: "ChatGPT", regex: /ChatGPT/i },
-  { family: "Grok", regex: /Grok/i },
-  { family: "Perplexity", regex: /Perplexity|pJsonScraper/i },
-  { family: "BingAI", regex: /BingPreview|BingAI|Bingbot|MS Search|msnbot/i },
-  { family: "Gemini", regex: /Gemini|Google-Extended|Google-LLM/i },
-  { family: "Anthropic", regex: /Anthropic/i },
-  { family: "GoogleAI", regex: /Google-LLM|GoogleAI|GoogleBot/i },
-  { family: "GenericAI", regex: /\b(?:AI|Bot)\b/i },
-];
+import LLM_SIGNATURES from "../signatures";
 
 async function hashIp(ip: string): Promise<string> {
   const data = new TextEncoder().encode(ip);


### PR DESCRIPTION
## Summary
- expose crawler signatures via `signatures/index.ts`
- import signatures in middleware instead of duplicating the list

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f55c3e474832ab80c1a6f6f59015c