### PR TITLE
Fix ESLint ignore path

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,1 @@
-src/app/api/log-bot/route.ts
+pages/api/log-bot.ts


### PR DESCRIPTION
## Summary
- point `.eslintignore` to the current log-bot API route

## Testing
- `npm run`

------
https://chatgpt.com/codex/tasks/task_e_684f558ad208832a8c6da86978fc343f