### PR TITLE
Add llm_family check in test script

### DIFF
--- a/scripts/test_pipeline.sh
+++ b/scripts/test_pipeline.sh
@@ -2,6 +2,12 @@
 #
 # Usage: ./scripts/test_pipeline.sh <BASE_URL>
 # Example: ./scripts/test_pipeline.sh http://localhost:3000
+#
+# The script hits the health-check endpoint using a set of
+# User-Agent strings. After each request it fetches the most
+# recent row from ClickHouse and verifies that the stored
+# `llm_family` matches the User-Agent under test. A mismatch
+# causes the script to exit with a non-zero status.
 
 HOST=${1:-http://localhost:3000}
 
@@ -14,7 +20,14 @@ for UA in "ChatGPT" "Claude/1.0" "BingAI/1.0" "Mozilla/5.0"; do
   RESP=$(curl -s -A "$UA" "$HOST/api/health-check")
   echo "  Response: $RESP"
   # fetch last row
-  LAST=$($CH_CLI "SELECT llm_family, path FROM default.llm_hits ORDER BY ts DESC LIMIT 1;")
+  LAST=$($CH_CLI "SELECT llm_family FROM default.llm_hits ORDER BY ts DESC LIMIT 1;")
   echo "  Last CH row: $LAST"
+  EXPECTED=${UA%%/*}
+  if [[ "$LAST" != "$EXPECTED" ]]; then
+    echo "  ❌ llm_family mismatch: expected '$EXPECTED' got '$LAST'"
+    exit 1
+  fi
   echo
 done
+
+echo "✅ All checks passed"


### PR DESCRIPTION
## Summary
- verify ClickHouse `llm_family` matches the User-Agent being tested
- document expected use in the test script

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f52464b94832a8c7d2f743c8b60a9