### PR TITLE
Clean stray prompt from type definitions

### DIFF
--- a/src/types/signatures.d.ts
+++ b/src/types/signatures.d.ts
@@ -12,4 +12,4 @@ declare module '*.json' {
     const value: Record<string, LLMSignature>;
     export default value;
   }
-  
+


### PR DESCRIPTION
## Summary
- fix stray shell prompt text at the end of `signatures.d.ts`

## Testing
- `npx tsc -p tsconfig.json`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f4a0577f0832aaa0db9c0375454a9