### PR TITLE
Update test script path

### DIFF
--- a/scripts/test_pipeline.sh
+++ b/scripts/test_pipeline.sh
@@ -10,8 +10,8 @@ CH_CLI="docker exec clickhouse-local clickhouse-client --user default --password
 
 for UA in "ChatGPT" "Claude/1.0" "BingAI/1.0" "Mozilla/5.0"; do
   echo "→ Testing UA: $UA"
-  # hit health-check
-  RESP=$(curl -s -A "$UA" "$HOST/api/health-check")
+  # hit root path to trigger middleware
+  RESP=$(curl -s -A "$UA" "$HOST/?test")
   echo "  Response: $RESP"
   # fetch last row
   LAST=$($CH_CLI "SELECT llm_family, path FROM default.llm_hits ORDER BY ts DESC LIMIT 1;")


### PR DESCRIPTION
## Summary
- modify `scripts/test_pipeline.sh` to hit `/` instead of `/api/health-check`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f5c23e6f8832aa279215db7f94a73