### PR TITLE
Fix missing LAMBDA_PROXY_URL handling

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -39,7 +39,12 @@ export async function middleware(request: Request) {
     userAgent: ua,
   };
 
-  const postUrl = process.env.LAMBDA_PROXY_URL || 'https://kbr5uzx2ugwjj2vrzkkjrgp5mm0fwkws.lambda-url.us-east-2.on.aws/';
+  const postUrl = process.env.LAMBDA_PROXY_URL;
+
+  if (!postUrl) {
+    console.error("[MIDDLEWARE] ❌ LAMBDA_PROXY_URL environment variable is missing");
+    return NextResponse.next();
+  }
 
   try {
     const response = await fetch(postUrl, {


### PR DESCRIPTION
## Summary
- remove default proxy URL in middleware
- emit an error log if `LAMBDA_PROXY_URL` isn't configured

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f5d4afb70832ab4fa965b00254bee