### PR TITLE
Add user_agent logging to Lambda and ClickHouse

### DIFF
--- a/clickhouse-conf/llm_hits.sql
+++ b/clickhouse-conf/llm_hits.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS llm_hits (
+  ts DateTime,
+  site_id String,
+  llm_family String,
+  path String,
+  ip_hash String,
+  user_agent String
+) ENGINE = MergeTree
+ORDER BY ts;

--- a/pages/api/log-bot.ts
+++ b/pages/api/log-bot.ts
@@ -7,7 +7,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     return res.status(405).json({ error: 'Method not allowed' })
   }
 
-  const { ts, siteId, llmFamily, path, ipHash } = req.body
+  const { ts, siteId, llmFamily, path, ipHash, userAgent } = req.body
 
   const parsedTs = typeof ts === 'number' ? new Date(ts * 1000) : new Date(ts)
   if (isNaN(parsedTs.getTime())) {
@@ -15,8 +15,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   const sql = `
-    INSERT INTO default.llm_hits (ts, site_id, llm_family, path, ip_hash)
-    VALUES ('${parsedTs.toISOString().replace('T', ' ').split('.')[0]}', '${siteId}', '${llmFamily}', '${path}', '${ipHash}')
+    INSERT INTO default.llm_hits (ts, site_id, llm_family, path, ip_hash, user_agent)
+    VALUES ('${parsedTs.toISOString().replace('T', ' ').split('.')[0]}', '${siteId}', '${llmFamily}', '${path}', '${ipHash}', '${userAgent}')
   `
 
   try {


### PR DESCRIPTION
## Summary
- include `userAgent` in log-bot Lambda SQL
- create `llm_hits` table definition including `user_agent` column

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f5d49acc8832aa5c134bb9c558e6d