### PR TITLE
Fix outdated eslintignore entry

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,1 @@
-src/app/api/log-bot/route.ts
+pages/api/log-bot.ts


### PR DESCRIPTION
## Summary
- point `.eslintignore` at `pages/api/log-bot.ts`

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684f5c349094832ab3488cc4168aa8e3