### PR TITLE
Use CLICKHOUSE_USER env and expand example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Example environment configuration
+
+# ── KAFKA (production – Redpanda Cloud) ─────────────────────────
+KAFKA_BROKER=d13pgevlr2pci89vo970.any.us-east-1.mpx.prd.cloud.redpanda.com:9092
+KAFKA_TOPIC=llm_hits
+KAFKA_USER=james-test
+KAFKA_PASS=VMtJ5oB7jTKogAZWzhwJaHKdmwuInV
+
+# ── CLOUD CLICKHOUSE ────────────────────────────────────────────────
+CLICKHOUSE_HTTP_URL=https://eb450p88ul.us-central1.gcp.clickhouse.cloud:8443
+CLICKHOUSE_URL=https://eb450p88ul.us-central1.gcp.clickhouse.cloud:8443
+CLICKHOUSE_USER=default
+CLICKHOUSE_PASSWORD=dVRVy2~U1JjOj
+
+# ── OTHER VARS ───────────────────────────────────────────────────────
+NEXT_PUBLIC_SITE_ID=nudgefactor.co.uk
+SALT=quickdemo
+LOG_ENDPOINT=/api/log-bot
+LAMBDA_PROXY_URL=https://kbr5uzx2ugwjj2vrzkkjrgp5mm0fwkws.lambda-url.us-east-2.on.aws/

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -18,6 +18,13 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
+## Environment
+
+Copy `.env.example` to `.env` (or `.env.production` for the ingest script) and
+set the values for the listed variables. The test pipeline script requires
+`CLICKHOUSE_USER` and `CLICKHOUSE_PASSWORD` while the ingest script also needs
+Kafka connection details.
+
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Learn More

--- a/scripts/test_pipeline.sh
+++ b/scripts/test_pipeline.sh
@@ -5,8 +5,10 @@
 
 HOST=${1:-http://localhost:3000}
 
-# Adjust these for your local ClickHouse creds:
-CH_CLI="docker exec clickhouse-local clickhouse-client --user default --password CqP0fqqmYD.2J --query"
+# Require ClickHouse credentials from the environment
+: "${CLICKHOUSE_USER:?CLICKHOUSE_USER not set}"
+: "${CLICKHOUSE_PASSWORD:?CLICKHOUSE_PASSWORD not set}"
+CH_CLI="docker exec clickhouse-local clickhouse-client --user ${CLICKHOUSE_USER} --password ${CLICKHOUSE_PASSWORD} --query"
 
 for UA in "ChatGPT" "Claude/1.0" "BingAI/1.0" "Mozilla/5.0"; do
   echo "→ Testing UA: $UA"


### PR DESCRIPTION
## Summary
- provide full environment sample with Kafka and ClickHouse variables
- replace CH_USER/CH_PASS with CLICKHOUSE_USER/CLICKHOUSE_PASSWORD in test pipeline
- explain env vars in README

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f5c29e79c832a8b0da77347356786