### PR TITLE
Replace password with env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,12 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Pipeline testing
+
+The `scripts/test_pipeline.sh` helper script uses a `CH_PASSWORD` environment
+variable to authenticate with your local ClickHouse instance:
+
+```bash
+CH_PASSWORD=mysecret ./scripts/test_pipeline.sh
+```

--- a/scripts/test_pipeline.sh
+++ b/scripts/test_pipeline.sh
@@ -6,7 +6,10 @@
 HOST=${1:-http://localhost:3000}
 
 # Adjust these for your local ClickHouse creds:
-CH_CLI="docker exec clickhouse-local clickhouse-client --user default --password CqP0fqqmYD.2J --query"
+# Set CH_PASSWORD to your ClickHouse user's password before running.
+# Example:
+#   CH_PASSWORD=mysecret ./scripts/test_pipeline.sh
+CH_CLI="docker exec clickhouse-local clickhouse-client --user default --password ${CH_PASSWORD} --query"
 
 for UA in "ChatGPT" "Claude/1.0" "BingAI/1.0" "Mozilla/5.0"; do
   echo "→ Testing UA: $UA"


### PR DESCRIPTION
## Summary
- reference a `CH_PASSWORD` env var in `test_pipeline.sh`
- document the variable in the README

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_684f6372bb50832a922eb45cfbc66dab