### PR TITLE
Make ClickHouse credentials configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables for local development
+
+# ClickHouse credentials used by scripts/test_pipeline.sh
+CH_USER=default
+CH_PASS=secret

--- a/README.md
+++ b/README.md
@@ -34,3 +34,14 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Environment Variables
+
+The `scripts/test_pipeline.sh` helper reads ClickHouse credentials from two environment variables:
+
+```bash
+CH_USER=default   # ClickHouse username
+CH_PASS=secret    # ClickHouse password
+```
+
+Copy `.env.example` to `.env` and adjust these values as needed.

--- a/scripts/test_pipeline.sh
+++ b/scripts/test_pipeline.sh
@@ -6,7 +6,10 @@
 HOST=${1:-http://localhost:3000}
 
 # Adjust these for your local ClickHouse creds:
-CH_CLI="docker exec clickhouse-local clickhouse-client --user default --password CqP0fqqmYD.2J --query"
+# You can override CH_USER and CH_PASS via environment variables.
+CH_USER=${CH_USER:-default}
+CH_PASS=${CH_PASS:-CqP0fqqmYD.2J}
+CH_CLI="docker exec clickhouse-local clickhouse-client --user $CH_USER --password $CH_PASS --query"
 
 for UA in "ChatGPT" "Claude/1.0" "BingAI/1.0" "Mozilla/5.0"; do
   echo "→ Testing UA: $UA"


### PR DESCRIPTION
## Summary
- use `CH_USER` and `CH_PASS` env vars in `test_pipeline.sh`
- document these variables
- add `.env.example`

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f67e1e4c4832a9a4ee7753270e626