### PR TITLE
Add env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Sample environment configuration
+# Copy to .env.production and set real values
+
+# ── KAFKA (Redpanda Cloud) ─────────────────────────
+KAFKA_BROKER=broker.example.com:9092
+KAFKA_TOPIC=llm_hits
+KAFKA_USER=your_kafka_user
+KAFKA_PASS=your_kafka_password
+
+# ── CLICKHOUSE ─────────────────────────────────────
+CLICKHOUSE_URL=https://your-clickhouse-url:8443
+CLICKHOUSE_USER=default
+CLICKHOUSE_PASSWORD=your_clickhouse_password
+
+# ── OTHER VARS ─────────────────────────────────────
+NEXT_PUBLIC_SITE_ID=your-site-id
+SALT=changeme
+LOG_ENDPOINT=/api/log-bot
+LAMBDA_PROXY_URL=https://your-lambda-proxy-url

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@ This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-
 
 ## Getting Started
 
+Copy `.env.example` to `.env.production` and fill in values for your Kafka and
+ClickHouse credentials. The ingestion script (`scripts/ingest.mjs`) loads this
+file automatically when run.
+
+### Required variables
+
+```
+KAFKA_BROKER
+KAFKA_TOPIC
+KAFKA_USER
+KAFKA_PASS
+CLICKHOUSE_URL
+CLICKHOUSE_USER
+CLICKHOUSE_PASSWORD
+LAMBDA_PROXY_URL
+```
+
 First, run the development server:
 
 ```bash


### PR DESCRIPTION
## Summary
- create `.env.example`
- document env vars in README
- allow `.env.example` in gitignore

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f6a430d64832ab1447f99aa0384c3