### PR TITLE
Update test_pipeline.sh ClickHouse creds

### DIFF
--- a/scripts/test_pipeline.sh
+++ b/scripts/test_pipeline.sh
@@ -2,11 +2,13 @@
 #
 # Usage: ./scripts/test_pipeline.sh <BASE_URL>
 # Example: ./scripts/test_pipeline.sh http://localhost:3000
+# CH_PASSWORD must contain the ClickHouse password.
 
 HOST=${1:-http://localhost:3000}
 
 # Adjust these for your local ClickHouse creds:
-CH_CLI="docker exec clickhouse-local clickhouse-client --user default --password CqP0fqqmYD.2J --query"
+# CH_PASSWORD is referenced below
+CH_CLI="docker exec clickhouse-local clickhouse-client --user default --password $CH_PASSWORD --query"
 
 for UA in "ChatGPT" "Claude/1.0" "BingAI/1.0" "Mozilla/5.0"; do
   echo "→ Testing UA: $UA"


### PR DESCRIPTION
## Summary
- use `$CH_PASSWORD` when calling the ClickHouse client
- document `CH_PASSWORD` setup in the test script

## Testing
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f7ad6b2a4832a8707d9a5c80db928