### PR TITLE
Remove fallback LAMBDA proxy URL

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -39,7 +39,11 @@ export async function middleware(request: Request) {
     userAgent: ua,
   };
 
-  const postUrl = process.env.LAMBDA_PROXY_URL || 'https://kbr5uzx2ugwjj2vrzkkjrgp5mm0fwkws.lambda-url.us-east-2.on.aws/';
+  const postUrl = process.env.LAMBDA_PROXY_URL;
+  if (!postUrl) {
+    console.error("[MIDDLEWARE] Missing LAMBDA_PROXY_URL environment variable");
+    return NextResponse.next();
+  }
 
   try {
     const response = await fetch(postUrl, {


### PR DESCRIPTION
## Summary
- remove default lambda URL from the middleware
- log a message when `LAMBDA_PROXY_URL` isn't set

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f7ad790b4832a8638489ab229df21