### PR TITLE
Update CH password handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,13 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## ClickHouse scripts
+
+Scripts such as `scripts/test_pipeline.sh` need your ClickHouse
+password. Set it via the `CH_PASSWORD` environment variable before
+running:
+
+```bash
+export CH_PASSWORD=your_clickhouse_password
+```

--- a/scripts/test_pipeline.sh
+++ b/scripts/test_pipeline.sh
@@ -6,7 +6,8 @@
 HOST=${1:-http://localhost:3000}
 
 # Adjust these for your local ClickHouse creds:
-CH_CLI="docker exec clickhouse-local clickhouse-client --user default --password CqP0fqqmYD.2J --query"
+# Set CH_PASSWORD to your ClickHouse user's password before running.
+CH_CLI="docker exec clickhouse-local clickhouse-client --user default --password ${CH_PASSWORD} --query"
 
 for UA in "ChatGPT" "Claude/1.0" "BingAI/1.0" "Mozilla/5.0"; do
   echo "→ Testing UA: $UA"


### PR DESCRIPTION
## Summary
- use `CH_PASSWORD` variable in `scripts/test_pipeline.sh`
- note `CH_PASSWORD` in README

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_684f7ee827d0832a8dbe71a63c5cbd47