### PR TITLE
Remove hardcoded lambda URL fallback

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -39,7 +39,11 @@ export async function middleware(request: Request) {
     userAgent: ua,
   };
 
-  const postUrl = process.env.LAMBDA_PROXY_URL || 'https://kbr5uzx2ugwjj2vrzkkjrgp5mm0fwkws.lambda-url.us-east-2.on.aws/';
+  const postUrl = process.env.LAMBDA_PROXY_URL;
+  if (!postUrl) {
+    console.warn('[MIDDLEWARE] LAMBDA_PROXY_URL environment variable is not set');
+    return NextResponse.next();
+  }
 
   try {
     const response = await fetch(postUrl, {


### PR DESCRIPTION
## Summary
- enforce use of `LAMBDA_PROXY_URL` and warn if it's missing

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f7ee97970832a83ced0802f663338