### PR TITLE
Ignore log-bot API for eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 src/app/api/log-bot/route.ts
+pages/api/log-bot.ts

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -10,6 +10,12 @@ const compat = new FlatCompat({
 });
 
 const eslintConfig = [
+  {
+    ignores: [
+      "src/app/api/log-bot/route.ts",
+      "pages/api/log-bot.ts",
+    ],
+  },
   ...compat.extends("next/core-web-vitals", "next/typescript"),
 ];
 


### PR DESCRIPTION
## Summary
- ignore `pages/api/log-bot.ts` in eslint
- keep ignore rules in `eslint.config.mjs`

## Testing
- `npx eslint .`

------
https://chatgpt.com/codex/tasks/task_e_684f7eeb0170832aa4227b741cbbf1d9