### PR TITLE
Update test_pipeline.sh to use CH_PASSWORD

### DIFF
--- a/scripts/test_pipeline.sh
+++ b/scripts/test_pipeline.sh
@@ -5,8 +5,9 @@
 
 HOST=${1:-http://localhost:3000}
 
-# Adjust these for your local ClickHouse creds:
-CH_CLI="docker exec clickhouse-local clickhouse-client --user default --password CqP0fqqmYD.2J --query"
+# Adjust these for your local ClickHouse creds.
+# Set `CH_PASSWORD` in your environment to the ClickHouse password.
+CH_CLI="docker exec clickhouse-local clickhouse-client --user default --password $CH_PASSWORD --query"
 
 for UA in "ChatGPT" "Claude/1.0" "BingAI/1.0" "Mozilla/5.0"; do
   echo "→ Testing UA: $UA"


### PR DESCRIPTION
## Summary
- replace hardcoded ClickHouse password with `$CH_PASSWORD`
- add comment describing the new env variable

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684f816d6648832aaedcf48dee8cf079