### PR TITLE
Update ESLint ignore for API log bot

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,3 @@
 src/app/api/log-bot/route.ts
+
+pages/api/log-bot.ts

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import { dirname } from "path";
 import { fileURLToPath } from "url";
+import fs from "fs";
 import { FlatCompat } from "@eslint/eslintrc";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -9,8 +10,17 @@ const compat = new FlatCompat({
   baseDirectory: __dirname,
 });
 
+const ignoreFile = fs.readFileSync(new URL(".eslintignore", import.meta.url), "utf8");
+const ignores = ignoreFile
+  .split(/\r?\n/)
+  .map((l) => l.trim())
+  .filter(Boolean);
+
 const eslintConfig = [
   ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    ignores,
+  },
 ];
 
 export default eslintConfig;


### PR DESCRIPTION
## Summary
- ignore `pages/api/log-bot.ts` via `.eslintignore`
- load ignore patterns in `eslint.config.mjs`

## Testing
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_684f817066c4832a8ae87acf9ef6a656