### PR TITLE
Use env var for ClickHouse password

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,14 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Testing the pipeline
+
+The `scripts/test_pipeline.sh` script exercises the ClickHouse ingestion flow. It
+expects your ClickHouse instance credentials and reads the password from the
+`CH_PASSWORD` environment variable. For example:
+
+```bash
+export CH_PASSWORD=<your-clickhouse-password>
+./scripts/test_pipeline.sh
+```

--- a/scripts/test_pipeline.sh
+++ b/scripts/test_pipeline.sh
@@ -6,7 +6,8 @@
 HOST=${1:-http://localhost:3000}
 
 # Adjust these for your local ClickHouse creds:
-CH_CLI="docker exec clickhouse-local clickhouse-client --user default --password CqP0fqqmYD.2J --query"
+# Use CH_PASSWORD environment variable for the ClickHouse password.
+CH_CLI="docker exec clickhouse-local clickhouse-client --user default --password $CH_PASSWORD --query"
 
 for UA in "ChatGPT" "Claude/1.0" "BingAI/1.0" "Mozilla/5.0"; do
   echo "→ Testing UA: $UA"


### PR DESCRIPTION
## Summary
- read `CH_PASSWORD` env var in test pipeline script
- document password variable in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f89f05dc4832aa47b786b2a69c2a5