### PR TITLE
Remove default Lambda URL from middleware

### DIFF
--- a/pages/api/log-bot.ts
+++ b/pages/api/log-bot.ts
@@ -31,9 +31,10 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       }
     )
     res.status(200).json({ status: 'inserted' })
-  } catch (err: any) {
+  } catch (err: unknown) {
     console.error('[INSERT ERROR]', err)
-    res.status(502).json({ error: 'Proxy request failed', details: err.message })
+    const message = err instanceof Error ? err.message : 'Unknown error'
+    res.status(502).json({ error: 'Proxy request failed', details: message })
   }
 }
 

--- a/scripts/ingest.mjs
+++ b/scripts/ingest.mjs
@@ -109,7 +109,7 @@ await consumer.run({
       const d = new Date(evt.ts);
       if (isNaN(d.getTime())) throw new Error('Invalid date');
       timestamp = d.toISOString().replace('T', ' ').split('.')[0];
-    } catch (err) {
+    } catch {
       console.error(`❌ Skipping invalid timestamp at offset ${message.offset}:`, evt.ts);
       return;
     }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -39,7 +39,11 @@ export async function middleware(request: Request) {
     userAgent: ua,
   };
 
-  const postUrl = process.env.LAMBDA_PROXY_URL || 'https://kbr5uzx2ugwjj2vrzkkjrgp5mm0fwkws.lambda-url.us-east-2.on.aws/';
+  const postUrl = process.env.LAMBDA_PROXY_URL;
+  if (!postUrl) {
+    console.warn('[MIDDLEWARE] ⚠️ LAMBDA_PROXY_URL env var is not set; skipping analytics log');
+    return NextResponse.next();
+  }
 
   try {
     const response = await fetch(postUrl, {


### PR DESCRIPTION
## Summary
- remove fallback from `LAMBDA_PROXY_URL`
- warn if the variable is not defined
- fix lint issues in `log-bot` API route and `ingest` script

## Testing
- `npx eslint .` *(fails: 5462 problems)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684f84c07bf8832abe8c528dd2263b78